### PR TITLE
fix(promt): fix issues with fs.write

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ module.exports = {
         temp.open(null, function(err, info) {
           /* istanbul ignore else */
           if (!err) {
-            fs.write(info.fd, buildCommit(answers, config));
+            fs.write(info.fd, buildCommit(answers, config), function() {});
             fs.close(info.fd, function(err) {
               editor(info.path, function (code, sig) {
                 if (code === 0) {


### PR DESCRIPTION
In latest node versions
fs.write(fd, string[, position[, encoding]], callback)
The callback parameter is no longer optional. Not passing it will throw a TypeError at runtime.